### PR TITLE
Remove id token from users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,9 +14,6 @@ class User < ApplicationRecord
   EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
   SCREEN_NAME_REGEXP = /\A[0-9a-zA-Z_]{1,15}\z/i
 
-  validates :id_token, presence: true, uniqueness: true
-
-  before_validation -> { self.id_token = SecureRandom.uuid if id_token.blank? }
   before_validation do
     self.email = email.downcase if email
     self.screen_name = screen_name.downcase if screen_name

--- a/db/migrate/20180228012223_add_id_token_to_posts.rb
+++ b/db/migrate/20180228012223_add_id_token_to_posts.rb
@@ -1,6 +1,6 @@
 class AddIdTokenToPosts < ActiveRecord::Migration[5.1]
   def change
-    add_column :posts, :id_token, :string, null: false, after: :id
+    add_column :posts, :id_token, :string, null: false, after: :id # NOTE: Use after when needed. Otherwise, a new column comes last.
     add_index :posts, :id_token, unique: true
   end
 end

--- a/db/migrate/20180228084953_remove_id_token_from_users.rb
+++ b/db/migrate/20180228084953_remove_id_token_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveIdTokenFromUsers < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :users, :id_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180228023042) do
+ActiveRecord::Schema.define(version: 20180228084953) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,9 +45,7 @@ ActiveRecord::Schema.define(version: 20180228023042) do
     t.datetime "reset_password_email_sent_at"
     t.string "name", limit: 20
     t.string "screen_name", limit: 15, null: false
-    t.string "id_token", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["id_token"], name: "index_users_on_id_token", unique: true
     t.index ["name"], name: "index_users_on_name"
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,16 +5,6 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
   let(:user) { create(:user) }
 
-  it 'has id_token' do
-    # NOTE: Returns a User's not saved.
-    user = build(:user)
-    expect(user.id_token).to be_nil
-    # NOTE: Use save! instead of save in specs to raise an exception when there is.
-    #   You might need to user.reload sometimes in specs although this is not the case here.
-    user.save!
-    expect(user.id_token).to be_present
-  end
-
   it 'has many followers' do
     user.followers << create_list(:user, 2)
     expect(user.followers.size).to eq(2)


### PR DESCRIPTION
Reverted the following PR because `User` is identical by `email`. So `id_token` is not needed.
https://github.com/jp-ryuji/twitter_clone_ruby/pull/29/files