### PR TITLE
Upgrade ruby to 2.7.8 v2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ AllCops:
 Bundler/OrderedGems:
   Exclude:
     - Gemfile
-Metrics/LineLength:
+Layout/LineLength:
   Max: 150
 Metrics/MethodLength:
   Max: 15

--- a/Gemfile
+++ b/Gemfile
@@ -86,8 +86,8 @@ group :test do
   gem 'capybara'
   gem 'capybara-email'
   gem 'email_spec'
-  gem 'selenium-webdriver'
-  gem 'chromedriver-helper'
+  # gem 'selenium-webdriver'
+  # gem 'chromedriver-helper'
   gem 'vcr'
   gem 'webmock'
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,8 +52,6 @@ GEM
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.2)
     autoprefixer-rails (10.4.13.0)
@@ -98,9 +96,6 @@ GEM
       activesupport
     childprocess (4.1.0)
     choice (0.2.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -168,7 +163,6 @@ GEM
     ice_nine (0.11.2)
     iniparse (1.5.0)
     interception (0.5)
-    io-like (0.3.1)
     jquery-rails (4.5.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -383,7 +377,6 @@ GEM
       rexml
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    rubyzip (2.3.2)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -401,10 +394,6 @@ GEM
       tilt
     scss_lint (0.60.0)
       sass (~> 3.5, >= 3.5.5)
-    selenium-webdriver (4.9.0)
-      rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
-      websocket (~> 1.0)
     semantic_range (3.0.0)
     settingslogic (2.0.9)
     shellany (0.0.1)
@@ -479,7 +468,6 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
-    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -500,7 +488,6 @@ DEPENDENCIES
   bundler-audit
   capybara
   capybara-email
-  chromedriver-helper
   dotenv-rails
   email_spec
   factory_bot_rails
@@ -537,7 +524,6 @@ DEPENDENCIES
   rubocop-rspec
   sass-rails (~> 6.0)
   scss_lint
-  selenium-webdriver
   settingslogic
   simple_form
   simplecov


### PR DESCRIPTION
Disabled `selenium-webdriver` and `chromedriver-helper` for now to prevent the following errors.

```
$ bundle exec rspec

An error occurred while loading ./spec/data_uploaders/users_csv_exporter_spec.rb.
Failure/Error: require File.expand_path('../config/environment', __dir__)

NoMethodError:
  undefined method `driver_path=' for Selenium::WebDriver::Chrome:Module
# ./vendor/bundle/ruby/2.7.0/gems/chromedriver-helper-2.1.1/lib/chromedriver-helper.rb:4:in `<top (required)>'
# ./config/application.rb:7:in `<top (required)>'
# ./config/environment.rb:2:in `require_relative'
# ./config/environment.rb:2:in `<top (required)>'
# ./spec/rails_helper.rb:6:in `require'
# ./spec/rails_helper.rb:6:in `<top (required)>'
# ./spec/data_uploaders/users_csv_exporter_spec.rb:3:in `require'
# ./spec/data_uploaders/users_csv_exporter_spec.rb:3:in `<top (required)>'

An error occurred while loading ./spec/data_uploaders/users_csv_importer_spec.rb.
Failure/Error: require File.expand_path('../config/environment', __dir__)

NoMethodError:
  undefined method `driver_path=' for Selenium::WebDriver::Chrome:Module
```